### PR TITLE
Standardize the published artifacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,17 +103,7 @@ lazy val publishSettings = Seq(
   },
   pomIncludeRepository := { _ => false },
   publishMavenStyle := true,
-  publishConfiguration := publishConfiguration.value.withOverwrite(true),
-  pomPostProcess := { node: XmlNode =>
-    val rule = new RewriteRule {
-      override def transform(n: XmlNode): XmlNodeSeq = n match {
-        case e: Elem if e != null && e.label == "artifactId" && e.text == "sbt-bom" =>
-          <artifactId>sbt-bom_2.12_1.0</artifactId>
-        case _ => n
-      }
-    }
-    new RuleTransformer(rule).transform(node).head
-  }
+  publishConfiguration := publishConfiguration.value.withOverwrite(true)
 )
 
 ThisBuild / pomExtra :=

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.8


### PR DESCRIPTION
See #6 and #4 for context.

The released artifacts followed a unique pattern, see https://repo1.maven.org/maven2/com/here/platform/sbt-bom_2.12_1.0/1.0.4/sbt-bom-1.0.4.pom. In the path, we use `sbt-bom_2.12_1.0` and then in the file name it is `sbt-bom-1.0.4.pom`, and finally in the POM content the `artifactID` is `sbt-bom_2.12_1.0`.

I am not sure exactly why the `artifactID` was changed like that in #4 (and also #1), but that `artifactID` is not consistent with the file name.

I think the way to go is to use sbt 1.9.x, which will publish two files:

- sbt-bom-x.jar, whose `artifactID` will be sbt-bom,
- sbt-bom_2.12_1.0-x.jar, whose `artifactID` will be sbt-bom_2.12_1.0.

That should at least fix #6, but I am not 100% it will also solve the problem that led to #4. I believe the only way to test it is to cut an RC release (`publishLocal` uses the local Ivy repository).