### PR TITLE
Extract list of dependencies from the BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ The following text provides a step-by-step guide on how to import [Jackson BOM](
 
 ### Load the plugin
 
-Enable the `MAVEN_CENTRAL` repository with a special `pattern` configuration:
+Add the `sbt-bom` plugin to `plugins.sbt` file.
+```scala
+addSbtPlugin("com.here.platform" % "sbt-bom" % "1.0.7")
+```
+
+If you're encountering issues or using earlier versions, you might have to explicitly declare the Maven Central repository:
 ```scala
 resolvers += Resolver.url(
   "MAVEN_CENTRAL",
@@ -30,11 +35,6 @@ resolvers += Resolver.url(
   Patterns("[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]") )
 ```
 This will enable the project to access plugin files stored in Maven Central, https://repo.maven.apache.org/maven2/com/here/platform/sbt-bom_2.12_1.0/.
-
-Add the `sbt-bom` plugin to `plugins.sbt` file.
-```scala
-addSbtPlugin("com.here.platform" % "sbt-bom" % "1.0.1")
-```
 
 ### Read & use a BOM
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The credentials can be supplied through these methods, with the following preced
 - Andrii Banias (https://github.com/abanias)
 - Anton Wilhelm (https://github.com/devtonhere)
 - Dmitry Abramov (https://github.com/dmitriy-abramov)
+- Gaël Jourdan-Weil (https://github.com/gaeljw)
 
 ## License
 Copyright (C) 2019-2024 HERE Europe B.V.

--- a/plugin/src/main/scala/com/here/bom/Bom.scala
+++ b/plugin/src/main/scala/com/here/bom/Bom.scala
@@ -55,6 +55,10 @@ object Bom {
     }
   }
 
+  def dependencies(bomArtifact: ModuleID): Def.Setting[Seq[ModuleID]] = {
+    read(bomArtifact)(bom => bom.bomDependencies)
+  }
+
   implicit def addBomSyntax(dep: OrganizationArtifactName): BomSyntax = new BomSyntax(dep)
 
   class BomSyntax(dep: OrganizationArtifactName) {
@@ -85,4 +89,9 @@ object Bom {
 
 trait Bom {
   def version(dependency: OrganizationArtifactName): String
+
+  /**
+   * List of all dependencies declared in the BOM
+   */
+  def bomDependencies: Seq[ModuleID]
 }

--- a/plugin/src/main/scala/com/here/bom/internal/BomReader.scala
+++ b/plugin/src/main/scala/com/here/bom/internal/BomReader.scala
@@ -155,6 +155,13 @@ class BomReader(pomLocator: IvyPomLocator, logger: Logger, scalaBinaryVersion: S
             sys.error(s"Version for ${normalized.group}.${normalized.name} not found in BOM")
           )
       }
+
+      override def bomDependencies: Seq[ModuleID] = {
+        effectiveVersions.map { case ((group, name), version) =>
+          ModuleID(group, name, version)
+        }.toSeq
+      }
+
     }
   }
 

--- a/plugin/src/test/scala/com/here/bom/internal/BomReaderSpec.scala
+++ b/plugin/src/test/scala/com/here/bom/internal/BomReaderSpec.scala
@@ -44,6 +44,8 @@ class BomReaderSpec extends AnyFlatSpec with Matchers with MockFactory {
 
     val dependency = "com.test" %% "test_module" % bom
     dependency.revision should be("1.0")
+
+    bom.bomDependencies shouldBe Seq("com.test" % "test_module_2.12" % "1.0")
   }
 
   "BomReader" should "assemble the BOM correctly with parent" in {
@@ -55,13 +57,15 @@ class BomReaderSpec extends AnyFlatSpec with Matchers with MockFactory {
 
     (pomLocatorMock.getPomFile _)
       .expects(where((moduleId: NormalizedArtifact) => {
-        moduleId.group.equals("com.test") && moduleId.name.equals("test_bom_parent") && moduleId.version.equals("1.0")
+        moduleId.group.equals("com.test") && moduleId.name
+          .equals("test_bom_parent") && moduleId.version.equals("1.0")
       }))
       .returns(Some(createMockPomFile("com.test", "test_bom_parent", "1.0", false)))
 
     (pomLocatorMock.getPomFile _)
       .expects(where((moduleId: NormalizedArtifact) => {
-        moduleId.group.equals("com.test") && moduleId.name.equals("test_bom") && moduleId.version.equals("1.0")
+        moduleId.group.equals("com.test") && moduleId.name.equals("test_bom") && moduleId.version
+          .equals("1.0")
       }))
       .returns(Some(createMockPomFile("com.test", "test_bom", "1.0", true)))
 
@@ -70,9 +74,16 @@ class BomReaderSpec extends AnyFlatSpec with Matchers with MockFactory {
 
     val dependency = "com.test" %% "test_module" % bom
     dependency.revision should be("1.0")
+
+    bom.bomDependencies shouldBe Seq("com.test" % "test_module_2.12" % "1.0")
   }
 
-  private def createMockPomFile(groupId: String, artifactId: String, version: String, addParent: Boolean): File = {
+  private def createMockPomFile(
+      groupId: String,
+      artifactId: String,
+      version: String,
+      addParent: Boolean
+  ): File = {
     val tempFile = File.createTempFile("mock", ".xml")
 
     val pomContent =
@@ -81,8 +92,7 @@ class BomReaderSpec extends AnyFlatSpec with Matchers with MockFactory {
          |  <groupId>$groupId</groupId>
          |  <artifactId>$artifactId</artifactId>
          |  <version>$version</version>
-         |  ${
-        if (addParent)
+         |  ${if (addParent)
           s"""
              |  <parent>
              |    <groupId>$groupId</groupId>
@@ -101,8 +111,7 @@ class BomReaderSpec extends AnyFlatSpec with Matchers with MockFactory {
              |         |      </dependency>
              |         |    </dependencies>
              |</dependencyManagement>
-             |""".stripMargin
-      }
+             |""".stripMargin}
          |</project >
          | """.stripMargin
 


### PR DESCRIPTION
Solves #9 

This adds:
- a `bomDependencies: Seq[ModuleID]` method to `Bom` instances
- a `Bom.dependencies(...)` helper method in the companion object for cases where you only care about `bomDependencies` but don't need to extract anything else manually from the `Bom`

I've also updated the README with documentation on this new usage and small changes (each in a different commit).

### Tests

I've tested this locally using the example described in #9 and it works successfully.

Example `build.sbt` file:
```scala
import sbt._
import com.here.bom.Bom

lazy val jacksonBom = Bom.dependencies("com.fasterxml.jackson" % "jackson-bom" % "2.16.0")

lazy val `sbt-bom-example-github` = project
  .in(file("."))
  .settings(jacksonBom)
  .settings(
    name := "sbt-bom-example-github",
    // resolvers := Resolver.mavenCentral +: resolvers.value,
    libraryDependencies += "com.typesafe.play" %% "play" % "2.8.21",
    libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.0",
    dependencyOverrides ++= jacksonBom.key.value,
  )
```

Which gives the expected result in terms of versions. Here's a `sbt dependencyTree` extract:
```
[info] sbt-bom-example-github:sbt-bom-example-github_2.12:0.1.0-SNAPSHOT [S]
[info]   +-com.fasterxml.jackson.module:jackson-module-scala_2.12:2.16.0
[info]   +-com.typesafe.play:play_2.12:2.8.21 [S]
[info]     +-com.fasterxml.jackson.core:jackson-annotations:2.16.0
[info]     +-com.fasterxml.jackson.core:jackson-core:2.16.0
[info]     +-com.fasterxml.jackson.core:jackson-databind:2.16.0
[info]     | +-com.fasterxml.jackson.core:jackson-annotations:2.16.0
[info]     | +-com.fasterxml.jackson.core:jackson-core:2.16.0
[info]     | 
[info]     +-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.0
[info]     | +-com.fasterxml.jackson.core:jackson-core:2.16.0
[info]     | +-com.fasterxml.jackson.core:jackson-databind:2.16.0
[info]     |   +-com.fasterxml.jackson.core:jackson-annotations:2.16.0
[info]     |   +-com.fasterxml.jackson.core:jackson-core:2.16.0
[info]     |   
[info]     +-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.0
[info]     | +-com.fasterxml.jackson.core:jackson-annotations:2.16.0
[info]     | +-com.fasterxml.jackson.core:jackson-core:2.16.0
[info]     | +-com.fasterxml.jackson.core:jackson-databind:2.16.0
[info]     |   +-com.fasterxml.jackson.core:jackson-annotations:2.16.0
[info]     |   +-com.fasterxml.jackson.core:jackson-core:2.16.0
...
```