### PR TITLE
🐛 fix: use all resolvers to download BOM instead of only the added resolvers

### DIFF
--- a/plugin/src/main/scala/com/here/bom/Bom.scala
+++ b/plugin/src/main/scala/com/here/bom/Bom.scala
@@ -42,7 +42,9 @@ object Bom {
     key := {
       val logger = (update / sLog).value
       val ivyConfig = InlineIvyConfiguration()
-        .withResolvers((update / resolvers).value.to)
+        .withResolvers(
+          ((update / resolvers).value ++ (update / appResolvers).value.getOrElse(Seq.empty)).to
+        )
         .withUpdateOptions((update / updateOptions).value)
       loadCredentials(logger)
       val depRes = new DependencyResolutionProxy(IvyDependencyResolution(ivyConfig))


### PR DESCRIPTION
Aims to solve https://github.com/heremaps/here-sbt-bom/issues/7

Instead of only using `resolvers` (= the resolvers added explicitly added in the project), also add `appResolvers` in the list.

Example of difference behaviour between the two settings:
```
sbt:sbt-bom-example-github> show resolvers
[info] * my-company-in-project: https://artifactory.mycompany.net/artifactory/external

sbt:sbt-bom-example-github> show appResolvers
[info] Some(Vector(FileRepository(local, Patterns(ivyPatterns=Vector(${ivy.home}/local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(${ivy.home}/local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), FileConfiguration(true, None)), URLRepository(ivy-proxy-releases, Patterns(ivyPatterns=Vector(https://artifactory.mycompany.net/artifactory/ivy-remote-repos/[organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://artifactory.mycompany.net/artifactory/ivy-remote-repos/[organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false), mycompany-releases-repo: https://artifactory.mycompany.net/artifactory/internal-releases, mycompany-snapshots-repo: https://artifactory.mycompany.net/artifactory/internal-snapshots, external: https://artifactory.mycompany.net/artifactory/external))
```

Because I have the following in my `~/.sbt/repositories` file:
```
[repositories]
local

#### artifactory.mycompany.net
ivy-proxy-releases: https://artifactory.mycompany.net/artifactory/ivy-remote-repos/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
mycompany-releases-repo: https://artifactory.mycompany.net/artifactory/internal-releases
mycompany-snapshots-repo: https://artifactory.mycompany.net/artifactory/internal-snapshots
external: https://artifactory.mycompany.net/artifactory/external
```