### PR TITLE
Allow BOM module to be inferred from setting key

### DIFF
--- a/plugin/src/test/scala/com/here/bom/BomSpec.scala
+++ b/plugin/src/test/scala/com/here/bom/BomSpec.scala
@@ -36,4 +36,17 @@ class BomSpec extends AnyFunSuite with OneInstancePerTest with MockFactory {
     result should not be (null)
   }
 
+  test("bom setting key") {
+    val b = settingKey[ModuleID]("test")
+    b := {
+      ModuleID("", "", "")
+        .withCrossVersion(CrossVersion.full)
+        .withExtraAttributes(Map())
+        .withConfigurations(None)
+        .branch("")
+    }
+    val result = Bom.apply(b)
+    result should not be (null)
+  }
+
 }


### PR DESCRIPTION
Support use case like:

```
lazy val bomModuleID = settingKey[ModuleID]("bom module ID")
bomModuleID:= ModuleID(organization, name, version)
lazy val bom = Bom.dependencies(bomModuleID)
```

when, for example, `version` may not be hardcoded into the SBT build and is obtained from pom file like in https://github.com/apache/spark/pull/52760#discussion_r2469376079